### PR TITLE
Initialization after use of var

### DIFF
--- a/LinkedInIOSHelper/LinkedInHelper/LinkedInHelper.m
+++ b/LinkedInIOSHelper/LinkedInHelper/LinkedInHelper.m
@@ -113,6 +113,7 @@ NSString * StringOrEmpty(NSString *string) {
     self.clientSecret = clientSecret;
     self.applicationWithRedirectURL = redirectUrl;
     self.permissions = permissions;
+    self.sender = sender;
     
     NSString *lclState = state.length ? state : @"DCEEFWF45453sdffef424";
     self.service = [LinkedInServiceManager serviceForPresentingViewController:_sender
@@ -125,7 +126,6 @@ NSString * StringOrEmpty(NSString *string) {
     
     self.service.showActivityIndicator = self.showActivityIndicator;
     
-    _sender = sender;
     _userInfoSuccessBlock = successUserInfo;
     _dismissFailBlock = failure;
     


### PR DESCRIPTION
the var '_sender' was used before assign it, this may causes the auth viewcontroller is not presented and the user can't bring to the app the permissions.